### PR TITLE
Allow essentials package to install on Masonite 2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-masonite>=2.1.0,<2.2.0
+masonite>=2.1.0,<2.3.0
 pytest
 coveralls
 flake8

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ setup(
         'masonite.contrib.essentials.middleware',
         'masonite.contrib.essentials.providers',
     ],
-    version='0.0.1',
+    version='0.0.2',
     install_requires=[
-        'masonite>=2.1,<2.2'
+        'masonite>=2.1,<2.3'
     ],
     extras_require={
         'hashids': ['hashids>=1.2,<1.3']


### PR DESCRIPTION
I *think* this might be all that is needed (and obviously a tagged release)?

~Testing it out now on a project I'm working on~

UPDATE: This seems to be working for me